### PR TITLE
feat: clean up multi lang support

### DIFF
--- a/lib/resolveLocaleFromNext.js
+++ b/lib/resolveLocaleFromNext.js
@@ -1,0 +1,18 @@
+import { localeOverrides } from '../prismicio';
+
+/**
+ * Resolves a locale from Next.js into one that Prismic uses.
+ *
+ * @param {string} nextLocale
+ *
+ * @returns {string} The resolved locale.
+ */
+export function resolveLocaleFromNext(nextLocale) {
+    const entries = Object.entries(localeOverrides);
+
+    const overrideEntry = entries.find(([_original, override]) => {
+        return override === nextLocale;
+    });
+
+    return overrideEntry ? overrideEntry[0] : nextLocale;
+}

--- a/lib/withAlternateLanguageURLs.js
+++ b/lib/withAlternateLanguageURLs.js
@@ -1,0 +1,29 @@
+import * as prismicH from '@prismicio/helpers';
+
+/**
+ * Adds a `url` property to each Prismic document's `alternate_language` element.
+ *
+ * This is useful when you need to link to a document's alternative language.
+ *
+ * @param {import("@prismicio/types").PrismicDocument} doc
+ * @param {import("@prismicio/client").Client} client
+ *
+ * @returns {Promise<import("@prismicio/types").PrismicDocument>}
+ */
+export const withAlternateLanguageURLs = async (doc, client) => {
+    const alternate_languages = await Promise.all(
+        doc.alternate_languages.map(async (alternateLanguage) => {
+            const doc = await client.getByID(alternateLanguage.id);
+
+            return {
+                ...alternateLanguage,
+                url: prismicH.asLink(doc)
+            };
+        })
+    );
+
+    return {
+        ...doc,
+        alternate_languages
+    };
+};

--- a/next.config.js
+++ b/next.config.js
@@ -3,7 +3,6 @@ const prismic = require('@prismicio/client');
 const sm = require('./sm.json');
 
 const localeOverrides = {
-    'en-ca': 'en-ca',
     'fr-wo': 'fr'
 };
 
@@ -13,20 +12,8 @@ const nextConfig = async () => {
 
     const repository = await client.getRepository();
     const locales = repository.languages.map(
-        (lang) => localeOverrides[lang.id]
+        (lang) => localeOverrides[lang.id] || lang.id
     );
-
-    // const languages = repository.languages;
-    // // console.log(languages);
-
-    // const locales = languages.map((lang) => {
-    //     if (lang.id === 'fr-wo') {
-    //         languages[1] = '/fr';
-    //         return '/fr';
-    //     }
-    //     return lang.id;
-    // });
-    // console.dir(locales[1]);
 
     return {
         reactStrictMode: true,

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -8,7 +8,7 @@ import Layout from '../components/layout/Layout';
 import Link from 'next/link';
 import { PrismicProvider } from '@prismicio/react';
 import { PrismicPreview } from '@prismicio/next';
-import { linkResolver, repositoryName } from '../prismicio';
+import { repositoryName } from '../prismicio';
 
 const lato = Lato({
     subsets: ['latin'],
@@ -21,14 +21,7 @@ export default function App({ Component, pageProps }) {
     const canonicalUrl = `https://marvingmoreton.com` + router.asPath;
 
     return (
-        <PrismicProvider
-            // linkResolver={linkResolver}
-            internalLinkComponent={({ href, children, locale, ...props }) => (
-                <Link legacyBehavior href={href} locale={locale}>
-                    <a {...props}>{children}</a>
-                </Link>
-            )}
-        >
+        <PrismicProvider internalLinkComponent={(props) => <Link {...props} />}>
             <PrismicPreview repositoryName={repositoryName}>
                 {/* <Layout> */}
                 <Head>

--- a/pages/index.js
+++ b/pages/index.js
@@ -5,6 +5,8 @@ import { components } from '../slices';
 import { SliceZone } from '@prismicio/react';
 import { useRouter } from 'next/router';
 import Layout from '../components/layout/Layout';
+import { resolveLocaleFromNext } from '../lib/resolveLocaleFromNext';
+import { withAlternateLanguageURLs } from '../lib/withAlternateLanguageURLs';
 
 export default function Homepage(props) {
     const router = useRouter();
@@ -81,23 +83,24 @@ export default function Homepage(props) {
 // }
 
 export async function getStaticProps({ previewData, locale }) {
-    // Prismic client
-    console.log(locale);
-    if (locale === 'fr') {
-        locale = 'fr-wo';
-    }
-    console.log(locale);
     const client = createClient({ previewData });
-    const page = await client.getSingle('homepage', { lang: locale });
+    const resolvedLocale = resolveLocaleFromNext(locale);
 
-    // const page = await client.getByUID('homepage', { lang: locale });
+    const page = await client.getSingle('homepage', {
+        lang: resolvedLocale
+    });
+    const pageWithAlternateLanguageURLs = await withAlternateLanguageURLs(
+        page,
+        client
+    );
+
     return {
         props: {
             metaTitle: page.data.meta_title,
             metaDescription: page.data.meta_description,
             ogImage: page.data.og_image.url,
             ogImageAlt: page.data.og_image.alt,
-            page: page
+            page: pageWithAlternateLanguageURLs
         }
     };
 }

--- a/prismicio.js
+++ b/prismicio.js
@@ -1,87 +1,93 @@
 import * as prismic from '@prismicio/client';
 import * as prismicNext from '@prismicio/next';
 import sm from './sm.json';
-import * as prismicH from '@prismicio/helpers';
 
 /**
  * The project's Prismic repository name.
  */
 export const repositoryName = prismic.getRepositoryName(sm.apiEndpoint);
+
+/**
+ * Locale overrides for nicer URLs.
+ */
+export const localeOverrides = {
+    'fr-wo': 'fr'
+};
+
 // Update the routes array to match your project's route structure
 /** @type {prismic.ClientConfig['routes']} **/
 const routes = [
     {
         type: 'homepage',
-        lang: 'en-ca',
-        path: '/'
+        path: '/:lang?'
     },
     {
         type: 'homepage',
-        lang: 'fr',
+        lang: 'fr-wo',
         path: '/fr'
     },
     {
         type: 'page',
-        lang: 'en-ca',
-        path: '/:uid'
+        path: '/:lang?/:uid'
     },
     {
         type: 'page',
-        lang: 'fr',
+        lang: 'fr-wo',
         path: '/fr/:uid'
     },
     {
         type: 'seo_mother',
-        lang: 'en-ca',
-        path: '/seo'
+        path: '/:lang?/seo'
     },
     {
         type: 'seo_mother',
-        lang: 'fr',
-        path: 'fr/seo'
+        lang: 'fr-wo',
+        path: '/fr/seo'
     },
     {
         type: 'seo_child',
-        lang: 'en-ca',
-        path: '/seo/:uid'
+        path: '/:lang?/seo/:uid'
     },
     {
         type: 'seo_child',
-        lang: 'fr',
-        path: 'fr/seo/:uid'
+        lang: 'fr-wo',
+        path: '/fr/seo/:uid'
     },
     {
         type: 'dev_mother',
-        lang: 'en-ca',
-        path: '/dev'
+        path: '/:lang?/dev'
     },
     {
         type: 'dev_mother',
-        lang: 'fr',
-        path: 'fr/dev/'
+        lang: 'fr-wo',
+        path: '/fr/dev'
     },
     {
         type: 'dev_child',
-        lang: 'en-ca',
-        path: '/dev/:uid'
+        path: '/:lang?/dev/:uid'
     },
     {
         type: 'dev_child',
-        lang: 'fr',
-        path: 'fr/dev/:uid'
-    },
-
-    { type: 'blog_homepage', lang: 'en-ca', path: '/blog' },
-    { type: 'blog_homepage', lang: 'fr', path: 'fr/blog' },
-    {
-        type: 'blog_post',
-        lang: 'en-ca',
-        path: '/blog/:uid'
+        lang: 'fr-wo',
+        path: '/fr/dev/:uid'
     },
     {
+        type: 'blog_homepage',
+        path: '/:lang?/blog'
+    },
+    {
+        type: 'blog_homepage',
+        lang: 'fr-wo',
+        path: '/fr/blog'
+    },
+    {
         type: 'blog_post',
-        lang: 'fr',
-        path: 'fr/blog/:uid'
+        path: '/:lang?/blog/:uid'
+    },
+    {
+        type: 'blog_post',
+        lang: 'fr-wo',
+        path: '/fr/blog/:uid'
     }
 ];
 


### PR DESCRIPTION
This PR cleans up the website's multi-language support with Prismic.

It introduces two new functions that should be used in `getStaticProps()`:

- `lib/resolveLocaleFromNext.js`: A function that converts a Next.js locale (e.g. `fr`) to a Prismic locale (`fr-wo`). Locale overrides are stored in `prismicio.js`'s `localeOverrides` constant.
- `lib/withAlternateLanguageURLs.js`: A function that adds a `url` property to each Prismic document's `alternate_language` element. Without using this function, alternative language documents do not have URLs in their object.

These functions have been applied to `pages/index.js` and `pages/[uid].js`. Study the changes made to those files and apply them to the rest of your pages.

If you have any questions, feel free to send them my way! :)
